### PR TITLE
Get rid of nohup

### DIFF
--- a/opera/run.sh
+++ b/opera/run.sh
@@ -6,11 +6,11 @@ echo "starting fantom opera"
 set -e
 
 cd
-nohup opera \
+opera \
   --nousb \
   --verbosity "${FANTOM_VERBOSITY}" \
   --cache "${FANTOM_CACHE}" \
   --genesis "/genesis/${FANTOM_GENESIS}" \
   --db.preset "${FANTOM_DB_PRESET}" \
-  --maxpeers "${FANTOM_MAX_PEERS}" &
+  --maxpeers "${FANTOM_MAX_PEERS}"
 

--- a/opera_full/run.sh
+++ b/opera_full/run.sh
@@ -15,6 +15,6 @@ nohup opera \
   --nousb \
   --verbosity "${FANTOM_VERBOSITY}" \
   --cache "${FANTOM_CACHE}" \
-  --genesis "/genesis/${FANTOM_GENESIS}"
+  --genesis "/genesis/${FANTOM_GENESIS}" \
   --db.preset "${FANTOM_DB_PRESET}" \
   --maxpeers "${FANTOM_MAX_PEERS}" &

--- a/opera_full/run.sh
+++ b/opera_full/run.sh
@@ -6,7 +6,7 @@ echo "starting fantom opera"
 set -e
 
 cd
-nohup opera \
+opera \
   --http \
   --http.addr "0.0.0.0" \
   --http.api "${FANTOM_API}" \
@@ -17,4 +17,4 @@ nohup opera \
   --cache "${FANTOM_CACHE}" \
   --genesis "/genesis/${FANTOM_GENESIS}" \
   --db.preset "${FANTOM_DB_PRESET}" \
-  --maxpeers "${FANTOM_MAX_PEERS}" &
+  --maxpeers "${FANTOM_MAX_PEERS}"

--- a/opera_snap/run.sh
+++ b/opera_snap/run.sh
@@ -15,7 +15,7 @@ nohup opera \
   --nousb \
   --verbosity "${FANTOM_VERBOSITY}" \
   --cache "${FANTOM_CACHE}" \
-  --genesis "/genesis/${FANTOM_GENESIS}"
+  --genesis "/genesis/${FANTOM_GENESIS}" \
   --syncmode snap \
   --db.preset "${FANTOM_DB_PRESET}" \
   --maxpeers "${FANTOM_MAX_PEERS}" &

--- a/opera_snap/run.sh
+++ b/opera_snap/run.sh
@@ -6,7 +6,7 @@ echo "starting fantom opera"
 set -e
 
 cd
-nohup opera \
+opera \
   --http \
   --http.addr "0.0.0.0" \
   --http.api "${FANTOM_API}" \
@@ -18,4 +18,4 @@ nohup opera \
   --genesis "/genesis/${FANTOM_GENESIS}" \
   --syncmode snap \
   --db.preset "${FANTOM_DB_PRESET}" \
-  --maxpeers "${FANTOM_MAX_PEERS}" &
+  --maxpeers "${FANTOM_MAX_PEERS}"


### PR DESCRIPTION
We can inspect the docker container log files by using below command

```
docker inspect -f {{.LogPath}} <<CONTAINER ID>>
```

Ex.: `docker inspect -f {{.LogPath}} b8ad9e1a2d42`
